### PR TITLE
Fix GCC_ARM build

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -56,7 +56,7 @@ int main()
 {
     while (true) {
         memset(buf, 0, sizeof(buf));
-        uint32_t actual;
+        size_t actual;
         bool good_read = pc.read(buf, sizeof(buf) - 1, &actual);
         if (!good_read) {
             cobs_errors++;


### PR DESCRIPTION
Conversion from 'uint32_t* {aka long unsigned int*}' to 'size_t* {aka
unsigned int*}' is invalid on arm-none-eabi-gcc v6.3.1.